### PR TITLE
random_ether_addr() must be renamed to eth_random_addr() for linux versions >= 5.16

### DIFF
--- a/kernel-module/igb/igb_main.c
+++ b/kernel-module/igb/igb_main.c
@@ -6508,7 +6508,7 @@ static int igb_vf_configure(struct igb_adapter *adapter, int vf)
 {
 	unsigned char mac_addr[ETH_ALEN];
 
-	random_ether_addr(mac_addr);
+	eth_random_addr(mac_addr);
 	igb_set_vf_mac(adapter, vf, mac_addr);
 
 #ifdef IFLA_VF_MAX
@@ -7026,7 +7026,7 @@ static void igb_vf_reset_event(struct igb_adapter *adapter, u32 vf)
 
 	/* generate a new mac address as we were hotplug removed/added */
 	if (!(adapter->vf_data[vf].flags & IGB_VF_FLAG_PF_SET_MAC))
-		random_ether_addr(vf_mac);
+		eth_random_addr(vf_mac);
 
 	/* process remaining reset events */
 	igb_vf_reset(adapter, vf);


### PR DESCRIPTION
see https://lore.kernel.org/netdev/20211013205450.328092-1-kuba@kernel.org/t/

> random_ether_addr() was the original name of the helper which
was kept for backward compatibility (?) after the rename in
commit 0a4dd594982a ("etherdevice: Rename random_ether_addr
to eth_random_addr").
>
> We have a single random_ether_addr() caller left in tree
while there are 70 callers of eth_random_addr().
Time to drop this define.

That change caused the following compile error on my arch linux machine running latest linux version 5.16.8, which I've fixed in my PR by renaming that function call:

```
  CC [M]  /home/e/avb4linux/kernel-module/igb/igb_main.o
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_vf_configure’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:6511:9: error: implicit declaration of function ‘random_ether_addr’ [-Werror=implicit-function-declaration]
 6511 |         random_ether_addr(mac_addr);
      |         ^~~~~~~~~~~~~~~~~
In file included from /home/e/avb4linux/kernel-module/igb/e1000_hw.h:28,
                 from /home/e/avb4linux/kernel-module/igb/e1000_api.h:28,
                 from /home/e/avb4linux/kernel-module/igb/igb.h:69,
                 from /home/e/avb4linux/kernel-module/igb/igb_main.c:69:
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_vmm_control’:
/home/e/avb4linux/kernel-module/igb/e1000_osdep.h:92:4: warning: this statement may fall through [-Wimplicit-fallthrough=]
   92 | do { \
      |    ^
/home/e/avb4linux/kernel-module/igb/igb_main.c:10016:17: note: in expansion of macro ‘E1000_WRITE_REG’
10016 |                 E1000_WRITE_REG(hw, E1000_DTXCTL, reg);
      |                 ^~~~~~~~~~~~~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c:10018:9: note: here
10018 |         case e1000_82580:
      |         ^~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_set_interrupt_capability’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:1147:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1147 |                 igb_reset_interrupt_capability(adapter);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c:1148:9: note: here
 1148 |         case IGB_INT_MODE_MSI:
      |         ^~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c:1149:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1149 |                 if (!pci_enable_msi(pdev))
      |                    ^
/home/e/avb4linux/kernel-module/igb/igb_main.c:1155:9: note: here
 1155 |         case IGB_INT_MODE_LEGACY:
      |         ^~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_set_fw_version’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:2558:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
 2558 |                 if (!(e1000_get_flash_presence_i210(hw))) {
      |                    ^
/home/e/avb4linux/kernel-module/igb/igb_main.c:2566:9: note: here
 2566 |         default:
      |         ^~~~~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_read’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:10377:9: warning: ignoring return value of ‘copy_to_user’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
10377 |         copy_to_user(buf, &adapter->last_event, sizeof(adapter->last_event));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘__igb_notify_dca’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:6471:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
 6471 |                 if (dca_add_requester(dev) == E1000_SUCCESS) {
      |                    ^
/home/e/avb4linux/kernel-module/igb/igb_main.c:6478:9: note: here
 6478 |         case DCA_PROVIDER_REMOVE:
      |         ^~~~
/home/e/avb4linux/kernel-module/igb/igb_main.c: In function ‘igb_has_link’:
/home/e/avb4linux/kernel-module/igb/igb_main.c:4796:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
 4796 |                 if (!hw->mac.get_link_status)
      |                    ^
/home/e/avb4linux/kernel-module/igb/igb_main.c:4798:9: note: here
 4798 |         case e1000_media_type_internal_serdes:
      |         ^~~~
cc1: some warnings being treated as errors
```