### PR TITLE
fix cloning of avdecc library submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jdksavdecc-c"]
 	path = jdksavdecc-c
-	url = git://github.com/jdkoftinoff/jdksavdecc-c
+	url = https://github.com/jdkoftinoff/jdksavdecc-c


### PR DESCRIPTION
Somehow the git:// URI scheme doesn't work anymore. Changing it to https:// for the git submodule fixes cloning of the submodule.